### PR TITLE
Example docker compose and Docker builds for prometheus and Kong.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,89 @@
+version: "3.3"
+services:
+  prometheus:
+    image: microkubes/prometheus:latest
+    volumes:
+      - "prometheus-data:/prometheus"
+    ports:
+      - 9090:9090
+
+  kong-database:
+      image: postgres:9.5
+      environment:
+        - POSTGRES_USER=kong
+        - POSTGRES_DB=kong
+      ports:
+        - 5432:5432
+      volumes:
+        - "postgres-data:/var/lib/postgresql/data"
+      deploy:
+        restart_policy:
+          condition: on-failure
+
+  kong-migration:
+    #image: kong:0.11.2
+    image: jormungandrk/kong:latest
+    environment:
+      - KONG_DATABASE=postgres
+      - KONG_PG_HOST=kong-database
+    secrets:
+        - source: kong-migrations
+          target: /migrations.sh
+          mode: 0740
+    entrypoint: "/docker-entrypoint.sh"
+    command: "/migrations.sh"
+
+  kong:
+    image: jormungandrk/kong:latest
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+      - "8443:8443"
+      - "8946:7946"
+      - "8946:7946/udp"
+    environment:
+      - KONG_DATABASE=postgres
+      - KONG_PG_HOST=kong-database
+      - KONG_PG_DATABASE=kong
+      - KONG_DNS_SERVER_NAME=consul
+      - KONG_DNS_SERVER_PORT=8600
+    deploy:
+      restart_policy:
+        condition: any
+
+  nginx:
+    image: nginx:latest
+    ports: 
+      - 10080:80
+
+
+  consul:
+    image: consul:1.0.1
+    volumes:
+      - "consul-data:/consul/data"
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:8600/udp"
+    command:
+      - "agent"
+      - "-server"
+      - "-client"
+      - "0.0.0.0"
+      - '-advertise={{ GetInterfaceIP "eth0" }}'
+      - "-recursor"
+      - "127.0.0.11"
+      - "-bootstrap"
+      - "-ui"
+    deploy:
+      restart_policy:
+        condition: any
+
+volumes:
+  prometheus-data:
+  postgres-data:
+  consul-data:
+
+secrets:
+  kong-migrations:
+    file: ./migrations.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,10 +26,7 @@ services:
     environment:
       - KONG_DATABASE=postgres
       - KONG_PG_HOST=kong-database
-    secrets:
-        - source: kong-migrations
-          target: /migrations.sh
-          mode: 0740
+      - CONSUL_URL=http://consul:8500
     entrypoint: "/docker-entrypoint.sh"
     command: "/migrations.sh"
 
@@ -47,6 +44,7 @@ services:
       - KONG_PG_DATABASE=kong
       - KONG_DNS_SERVER_NAME=consul
       - KONG_DNS_SERVER_PORT=8600
+      - CONSUL_URL=http://consul:8500
     deploy:
       restart_policy:
         condition: any
@@ -84,6 +82,3 @@ volumes:
   postgres-data:
   consul-data:
 
-secrets:
-  kong-migrations:
-    file: ./migrations.sh

--- a/docker/kong/Dockerfile
+++ b/docker/kong/Dockerfile
@@ -1,0 +1,33 @@
+FROM kong:0.11.2-alpine AS plugin-build
+
+RUN apk --no-cache add --update git lua luarocks zip
+
+#RUN git clone https://github.com/Microkubes/kong-plugin-prometheus.git
+COPY ./kong-plugin-prometheus kong-plugin-prometheus
+RUN cd kong-plugin-prometheus &&\
+    sed 's,git://github.com/Mashape/kong_plugin,https://github.com/Kong/kong-plugin,g' kong-plugin-prometheus-0.0.2-1.rockspec &&\ 
+    sed 's/tag = "0.1.0"/-- tag = "0.1.0"/g' kong-plugin-prometheus-0.0.2-1.rockspec &&\
+    luarocks make && \
+    luarocks pack kong-plugin-prometheus 0.0.2-1
+
+
+FROM kong:0.11.2-alpine
+
+RUN apk --no-cache add curl bind-tools
+
+COPY ./kong-entrypoint.sh /
+RUN chmod +x /kong-entrypoint.sh
+COPY ./kong.config /etc/kong/kong.config
+
+COPY --from=plugin-build /kong-plugin-prometheus/kong-plugin-prometheus-0.0.2-1.all.rock /
+RUN luarocks install kong-plugin-prometheus-0.0.2-1.all.rock &&\
+    rm kong-plugin-prometheus-0.0.2-1.all.rock
+
+ENTRYPOINT ["/kong-entrypoint.sh"]
+
+
+ENV KONG_NGINX_DAEMON=off
+ENV KONG_CONFIG_FILE=/etc/kong/kong.config
+
+#CMD ["/docker-entrypoint.sh", "/usr/local/openresty/nginx/sbin/nginx", "-c", "/usr/local/kong/nginx.conf", "-p", "/usr/local/kong/" , "-vv"]
+CMD ["kong", "start", "-c", "/etc/kong/kong.config", "-vv"]

--- a/docker/kong/Dockerfile
+++ b/docker/kong/Dockerfile
@@ -5,8 +5,6 @@ RUN apk --no-cache add --update git lua luarocks zip
 #RUN git clone https://github.com/Microkubes/kong-plugin-prometheus.git
 COPY ./kong-plugin-prometheus kong-plugin-prometheus
 RUN cd kong-plugin-prometheus &&\
-    sed 's,git://github.com/Mashape/kong_plugin,https://github.com/Kong/kong-plugin,g' kong-plugin-prometheus-0.0.2-1.rockspec &&\ 
-    sed 's/tag = "0.1.0"/-- tag = "0.1.0"/g' kong-plugin-prometheus-0.0.2-1.rockspec &&\
     luarocks make && \
     luarocks pack kong-plugin-prometheus 0.0.2-1
 

--- a/docker/kong/Dockerfile
+++ b/docker/kong/Dockerfile
@@ -2,8 +2,7 @@ FROM kong:0.11.2-alpine AS plugin-build
 
 RUN apk --no-cache add --update git lua luarocks zip
 
-#RUN git clone https://github.com/Microkubes/kong-plugin-prometheus.git
-COPY ./kong-plugin-prometheus kong-plugin-prometheus
+RUN git clone https://github.com/Microkubes/kong-plugin-prometheus.git
 RUN cd kong-plugin-prometheus &&\
     luarocks make && \
     luarocks pack kong-plugin-prometheus 0.0.2-1
@@ -14,6 +13,7 @@ FROM kong:0.11.2-alpine
 RUN apk --no-cache add curl bind-tools
 
 COPY ./kong-entrypoint.sh /
+COPY ./migrations.sh /migrations.sh
 RUN chmod +x /kong-entrypoint.sh
 COPY ./kong.config /etc/kong/kong.config
 

--- a/docker/kong/kong-entrypoint.sh
+++ b/docker/kong/kong-entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+function enable_kong_plugins(){
+  while true; do
+    is_kong_up=`curl -sSf http://localhost:8001/plugins 2>/dev/null || echo "false"` 
+    if [ "$is_kong_up" != "false"  ]; then 
+      # register plugin
+      curl "http://localhost:8001/plugins" -d "name=prometheus"
+      echo "Prometheus plugin enabled for all APIs"
+      break
+    fi
+    echo "Kong not up yet"
+    sleep 1
+  done
+}
+
+
+echo "Waiting for migrations to complete..."
+while [ "$response" != "200" ]; do
+	sleep 1
+	response=$(curl --write-out %{http_code} --silent --output /dev/null http://consul:8500/v1/kv/kong-migrations)
+done
+
+echo "Migrations complete."
+
+DNS_SERVER_IP=""
+if [ -n "$KONG_DNS_SERVER_NAME" ]; then
+  DNS_SERVER_IP=`dig +short "$KONG_DNS_SERVER_NAME"`
+  if [ -z "$DNS_SERVER_IP" ]; then
+    echo "DNS Server $KONG_DNS_SERVER_NAME not resolved"
+    exit 1
+  fi
+fi
+
+if [ -n "$KONG_DNS_SERVER_PORT" ]; then
+  DNS_SERVER_IP="$DNS_SERVER_IP:$KONG_DNS_SERVER_PORT"
+fi
+
+if [ -n "$DNS_SERVER_IP" ]; then
+  echo "Setting DNS resolver to: $DNS_SERVER_IP"
+  export KONG_DNS_RESOLVER="$DNS_SERVER_IP"
+fi
+
+# Register plugins
+enable_kong_plugins &
+
+# Run anything here
+exec "$@"

--- a/docker/kong/kong-entrypoint.sh
+++ b/docker/kong/kong-entrypoint.sh
@@ -5,8 +5,13 @@ function enable_kong_plugins(){
     is_kong_up=`curl -sSf http://localhost:8001/plugins 2>/dev/null || echo "false"` 
     if [ "$is_kong_up" != "false"  ]; then 
       # register plugin
-      curl "http://localhost:8001/plugins" -d "name=prometheus"
-      echo "Prometheus plugin enabled for all APIs"
+      prometheus_registered=`(curl -sSf http://localhost:8001/plugins 2>/dev/null | grep -i prometheus) || echo "false"`
+      if [ "$prometheus_registered" == "false" ]; then
+        curl "http://localhost:8001/plugins" -d "name=prometheus"
+        echo "Prometheus plugin enabled for all APIs. Restarting Kong"
+        kong stop
+      fi
+      echo "Prometheus plugin already registered."
       break
     fi
     echo "Kong not up yet"

--- a/docker/kong/kong.config
+++ b/docker/kong/kong.config
@@ -1,0 +1,1 @@
+custom-plugins=prometheus

--- a/docker/kong/migrations.sh
+++ b/docker/kong/migrations.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+echo "Running migrations"
+echo "Waiting for consul to come online..."
+while [ "$response" != "301" ]; do
+	sleep 1
+	response=$(curl --write-out %{http_code} --silent --output /dev/null http://consul:8500)
+done
+echo "Consul online."
+
+response=$(curl --write-out %{http_code} --silent --output /dev/null http://consul:8500/v1/kv/kong-migrations)
+
+if [ "$response" != "200" ]; then 
+	echo "Kong migrations failed."
+	kong migrations up || { echo "Error: kong migrations up failed" ; exit $?; }
+	curl -X PUT -d '{"migrations": "done"}' http://consul:8500/v1/kv/kong-migrations || \
+		{ echo "Error: Consul create/update key failed" ; exit $!; }
+fi
+
+echo "Migrations script done."
+

--- a/docker/kong/migrations.sh
+++ b/docker/kong/migrations.sh
@@ -12,7 +12,7 @@ response=$(curl --write-out %{http_code} --silent --output /dev/null http://cons
 if [ "$response" != "200" ]; then 
 	echo "Kong migrations failed."
 	kong migrations up || { echo "Error: kong migrations up failed" ; exit $?; }
-	curl -X PUT -d '{"migrations": "done"}' http://consul:8500/v1/kv/kong-migrations || \
+	curl -X PUT -d '{"migrations": "done"}' ${CONSUL_URL}/v1/kv/kong-migrations || \
 		{ echo "Error: Consul create/update key failed" ; exit $!; }
 fi
 

--- a/docker/prometheus/Dockerfile
+++ b/docker/prometheus/Dockerfile
@@ -1,0 +1,3 @@
+FROM prom/prometheus:v2.2.1
+
+COPY prometheus.yml /etc/prometheus/prometheus.yml

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,30 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+      monitor: 'microkubes-monitor'
+
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: "gateway"
+    scrape_interval: 5s
+    metrics_path: '/prometheus/metrics'
+    static_configs:
+      - targets: ['kong:8001']


### PR DESCRIPTION
Everything is put in "docker" directory.
There is an example configuration for swarm docker-compose.yml.
Prometheus is set up to track Kong gateway.
We have a plugin on Kong to expose prometheus metrics on /prometheus/metrics