### PR TITLE
Add apps-management to microkubes deployment

### DIFF
--- a/kubernetes/microkubes.yaml
+++ b/kubernetes/microkubes.yaml
@@ -1,6 +1,44 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  name: microservice-apps-management
+  namespace: microkubes
+  labels:
+    app: microservice-apps-management
+    platform: microkubes
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: microservice-apps-management
+      labels:
+        app: microservice-apps-management
+        platform: microkubes
+      annotations:
+        consul.register/enabled: "true"
+        consul.register/service.name: "microservice-apps-management"
+    spec:
+      containers:
+        - name: microservice-apps-management
+          image: microkubes/microservice-apps-management:latest
+          imagePullPolicy: Always
+          env:
+            - name: SERVICE_CONFIG_FILE
+              value: /config.json
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: microkubes-secrets 
+              mountPath: /run/secrets
+      volumes:
+        - name: microkubes-secrets 
+          secret:
+            secretName: microkubes-secrets
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
   name: microservice-user
   namespace: microkubes
   labels:


### PR DESCRIPTION
The microservice apps-management was missing from the deployment, now it's added. Please note that it currently doesn't work due to https://github.com/Microkubes/microservice-user-profile/commit/902d191e60e6959a08e3feb2c347d8bf660afbb5.